### PR TITLE
Add Optional Message Display to Spinner Frames

### DIFF
--- a/src/Spinner.php
+++ b/src/Spinner.php
@@ -16,13 +16,15 @@ class Spinner
     private $blink_on = "\e[?25h";
     private $clear_line = "\33[2K\r";
     private $return_to_left = "\r";
+    private ?string $message;
 
-    public function __construct(string $spinner = 'simpleDots', bool $use_keyboard_interrupts = true)
+    public function __construct(string $spinner = 'simpleDots', bool $use_keyboard_interrupts = true, ?string $message = null)
     {
         $this->use_keyboard_interrupts = $use_keyboard_interrupts;
         $spinner_json = file_get_contents(__DIR__ . '/spinners.json');
         $spinner_ary = json_decode($spinner_json, true);
         $this->spinner = $spinner_ary[$spinner];
+        $this->message = $message;
     }
 
     private function loopSpinnerFrames()
@@ -30,7 +32,7 @@ class Spinner
         echo $this->blink_off;
         while (true) {
             foreach ($this->spinner["frames"] as $frame) {
-                echo $frame . $this->return_to_left;
+                echo $frame. ($this->message ? ' ' . $this->message : '') . $this->return_to_left;
                 usleep($this->spinner["interval"] * 1000);
             }
         }


### PR DESCRIPTION
This pull request introduces an optional `message` property to the `Spinner` class. This message, when provided, is displayed after the spinner frame.

The `message` property is set through the constructor and defaults to `null` if not provided. The `loopSpinnerFrames` method has been modified to append the `message` to the spinner frame, if it is not `null`.

This feature allows users to provide additional context or information alongside the spinner, enhancing the user experience.

Here is an example of how to use this new feature:

```php
(new Spinner(spinner: 'dots', message: 'Loading...'))->callback(fn () => sleep(5));
```

In this example, the spinner will display 'Loading...' after each spinner frame. 
This change is backward compatible and does not affect existing usage of the Spinner class.